### PR TITLE
Add random access for row objects, get methods for compatibility

### DIFF
--- a/perf/perf-test.js
+++ b/perf/perf-test.js
@@ -28,6 +28,20 @@ function iterateValues(table) {
   names.forEach(name => Array.from(table.getChild(name)));
 }
 
+// random access to each column value
+// this will be slower if there are multiple record batches
+// due to the need for binary search over the offsets array
+function randomAccess(table) {
+  const { numRows, numCols } = table;
+  const vals = Array(numCols);
+  for (let j = 0; j < numCols; ++j) {
+    const col = table.getChildAt(j);
+    for (let i = 0; i < numRows; ++i) {
+      vals[j] = col.at(i);
+    }
+  }
+}
+
 // generate row objects, access each property
 function visitObjects(table) {
   const nr = table.numRows;
@@ -58,6 +72,7 @@ async function run(file) {
   trial('Parse Table from IPC', file, bytes, parseIPC, 10);
   trial('Extract Arrays', file, bytes, extractArrays, 10);
   trial('Iterate Values', file, bytes, iterateValues, 10);
+  trial('Random Access', file, bytes, randomAccess, 10);
   trial('Visit Row Objects', file, bytes, visitObjects, 5);
   console.log();
 }

--- a/src/util.js
+++ b/src/util.js
@@ -57,6 +57,29 @@ export function divide(num, div) {
   return toNumber(num / div) + toNumber(num % div) / toNumber(div);
 }
 
+/**
+ * Determine the correct index into an offset array for a given
+ * full column row index.
+ * @param {Int32Array} offsets The offsets array.
+ * @param {number} index The full column row index.
+ */
+export function bisectOffsets(offsets, index) {
+  // binary search for batch index
+  // we use a fast unsigned bit shift for division by two
+  // this assumes offsets.length <= Math.pow(2, 31), which seems safe
+  // otherwise that is a whole lotta record batches to handle in JS...
+  let a = 0;
+  let b = offsets.length;
+  do {
+    const mid = (a + b) >>> 1;
+    if (offsets[mid] <= index) a = mid + 1;
+    else b = mid;
+  } while (a < b);
+
+  // decrement to the desired offset array index
+  return --a;
+}
+
 // -- flatbuffer utilities -----
 
 /**

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -12,26 +12,40 @@ const values = [
 const table = tableFromIPC(await arrowFromDuckDB(values));
 
 describe('Table', () => {
-  it('provides row count', async () => {
+  it('provides row count', () => {
     assert.deepStrictEqual(table.numRows, 3);
   });
 
-  it('provides column count', async () => {
+  it('provides column count', () => {
     assert.deepStrictEqual(table.numCols, 1);
   });
 
-  it('provides child column accessors', async () => {
+  it('provides child column accessors', () => {
     const col = table.getChild('value');
     assert.strictEqual(col, table.getChildAt(0));
     assert.deepStrictEqual(col.toArray(), values);
   });
 
-  it('provides object array', async () => {
+  it('provides object array', () => {
     assert.deepStrictEqual(table.toArray(), values.map(value => ({ value })));
   });
 
-  it('provides column array map', async () => {
+  it('provides column array map', () => {
     assert.deepStrictEqual(table.toColumns(), { value: values });
+  });
+
+  it('provides random access via at/get', () => {
+    const idx = [0, 1, 2];
+
+    // table object random access
+    const obj = values.map(value => ({ value }));
+    assert.deepStrictEqual(idx.map(i => table.at(i)), obj);
+    assert.deepStrictEqual(idx.map(i => table.get(i)), obj);
+
+    // column value random access
+    const col = table.getChildAt(0);
+    assert.deepStrictEqual(idx.map(i => col.at(i)), values);
+    assert.deepStrictEqual(idx.map(i => col.get(i)), values);
   });
 
   it('provides select by index', async () => {


### PR DESCRIPTION
- Add `Table.at(index)` for random access to row object creation.
- Add `get(index)` methods to both Table and Column for better Apache Arrow JS compatibility.
- Add random access performance tests (showing Flechette currently ~2x faster).

Among other things, this PR should make flechette tables compatible with Observable Plot's built-in Arrow table support (observablehq/plot#2115).