### PR TITLE
Add struct/row proxy objects via useProxy option.

### DIFF
--- a/perf/perf-test.js
+++ b/perf/perf-test.js
@@ -4,7 +4,7 @@ import { tableFromIPC as flTable } from '../src/index.js';
 import { benchmark } from './util.js';
 
 // table creation
-const fl = bytes => flTable(bytes, { useBigInt: true });
+const fl = bytes => flTable(bytes, { useProxy: true, useBigInt: true });
 const aa = bytes => aaTable(bytes);
 
 // parse ipc data to columns

--- a/src/batch.js
+++ b/src/batch.js
@@ -733,18 +733,20 @@ export class DenseUnionBatch extends SparseUnionBatch {
  */
 export class StructBatch extends ArrayBatch {
   /**
-   * Create a new column batch.
+   * Create a new struct batch.
    * @param {object} options
    * @param {number} options.length The length of the batch
    * @param {number} options.nullCount The null value count
    * @param {Uint8Array} [options.validity] Validity bitmap buffer
    * @param {Batch[]} options.children Children batches
    * @param {string[]} options.names Child batch names
+   * @param {(names: string[], batches: Batch[]) =>
+   *  (index: number) => Record<string, any>} options.factory
+   *  Struct object factory creation method
    */
-  constructor({ names, ...rest }) {
+  constructor({ names, factory, ...rest }) {
     super(rest);
-    /** @type {string[]} */
-    this.names = names;
+    this.factory = factory(names, this.children);
   }
 
   /**
@@ -752,13 +754,7 @@ export class StructBatch extends ArrayBatch {
    * @returns {Record<string, any>}
    */
   value(index) {
-    const { children, names } = this;
-    const n = names.length;
-    const struct = {};
-    for (let i = 0; i < n; ++i) {
-      struct[names[i]] = children[i].at(index);
-    }
-    return struct;
+    return this.factory(index);
   }
 }
 

--- a/src/struct.js
+++ b/src/struct.js
@@ -1,0 +1,72 @@
+export const RowIndex = Symbol('rowIndex');
+
+/**
+ * Returns a row proxy object factory. The resulting method takes a
+ * batch-level row index as input and returns an object that proxies
+ * access to underlying batches.
+ * @param {string[]} names The column (property) names
+ * @param {import('./batch.js').Batch[]} batches The value batches.
+ * @returns {(index: number) => Record<string, any>}
+ */
+export function proxyFactory(names, batches) {
+  class RowObject {
+    /**
+     * Create a new proxy row object representing a struct or table row.
+     * @param {number} index The record batch row index.
+     */
+    constructor(index) {
+      this[RowIndex] = index;
+    }
+
+    /**
+     * Return a JSON-compatible object representation.
+     */
+    toJSON() {
+      return structObject(names, batches, this[RowIndex]);
+    }
+  };
+
+  // prototype for row proxy objects
+  const proto = RowObject.prototype;
+
+  for (let i = 0; i < names.length; ++i) {
+    // skip duplicated column names
+    if (Object.hasOwn(proto, names[i])) continue;
+
+    // add a getter method for the current batch
+    const batch = batches[i];
+    Object.defineProperty(proto, names[i], {
+      get() { return batch.at(this[RowIndex]); },
+      enumerable: true
+    });
+  }
+
+  return index => new RowObject(index);
+}
+
+/**
+ * Returns a row object factory. The resulting method takes a
+ * batch-level row index as input and returns an object whose property
+ * values have been extracted from the batches.
+ * @param {string[]} names The column (property) names
+ * @param {import('./batch.js').Batch[]} batches The value batches.
+ * @returns {(index: number) => Record<string, any>}
+ */
+export function objectFactory(names, batches) {
+  return index => structObject(names, batches, index);
+}
+
+/**
+ * Return a vanilla object representing a struct (row object) type.
+ * @param {string[]} names The column (property) names
+ * @param {import('./batch.js').Batch[]} batches The value batches.
+ * @param {number} index The record batch row index.
+ * @returns {Record<string, any>}
+ */
+export function structObject(names, batches, index) {
+  const obj = {};
+  for (let i = 0; i < names.length; ++i) {
+    obj[names[i]] = batches[i].at(index);
+  }
+  return obj;
+}

--- a/src/table-from-ipc.js
+++ b/src/table-from-ipc.js
@@ -42,7 +42,8 @@ import {
 } from './constants.js';
 import { parseIPC } from './parse-ipc.js';
 import { Table } from './table.js';
-import { keyFor, objectFactory, proxyFactory } from './util.js';
+import { objectFactory, proxyFactory } from './struct.js';
+import { keyFor } from './util.js';
 
 /**
  * Decode [Apache Arrow IPC data][1] and return a new Table. The input binary

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,4 +303,12 @@ export interface ExtractionOptions {
    * both `Map` and `Object.fromEntries` (default).
    */
   useMap?: boolean;
+  /**
+   * If true, extract Arrow 'Struct' values and table row objects using
+   * zero-copy proxy objects that extract data from underlying Arrow batches.
+   * The proxy objects can improve performance and reduce memory usage, but
+   * do not support property enumeration (`Object.keys`, `Object.values`,
+   * `Object.entries`) or spreading (`{ ...object }`).
+   */
+  useProxy?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Batch } from './batch.js';
 import {
   Version,
   Endianness,
@@ -92,6 +93,9 @@ export type TypedArrayConstructor =
 export interface ValueArray<T> extends ArrayLike<T>, Iterable<T> {
   slice(start?: number, end?: number): ValueArray<T>;
 }
+
+/** Struct/row object factory method. */
+export type StructFactory = (names: string[], batches: Batch<any>[]) => (index: number) => Record<string, any>;
 
 /** Custom metadata. */
 export type Metadata = Map<string, string>;

--- a/src/util.js
+++ b/src/util.js
@@ -87,59 +87,6 @@ export function bisect(offsets, index) {
   return a;
 }
 
-export const RowIndex = Symbol('rowIndex');
-
-/**
- * Returns a row proxy object factory. The resulting method takes a
- * batch-level row index as input and returns an object that proxies
- * access to underlying batches.
- * @param {string[]} names The column (property) names
- * @param {import('./batch.js').Batch[]} batches The value batches.
- * @returns {(index: number) => Record<string, any>}
- */
-export function proxyFactory(names, batches) {
-  class RowObject {
-    constructor(index) {
-      this[RowIndex] = index;
-    }
-  };
-
-  // prototype for row proxy objects
-  const proto = RowObject.prototype;
-
-  for (let i = 0; i < names.length; ++i) {
-    // skip duplicated column names
-    if (Object.hasOwn(proto, names[i])) continue;
-
-    // add a getter method for the current batch
-    const batch = batches[i];
-    Object.defineProperty(proto, names[i], {
-      get() { return batch.at(this[RowIndex]); },
-      enumerable: true
-    });
-  }
-
-  return (index) => new RowObject(index);
-}
-
-/**
- * Returns a row object factory. The resulting method takes a
- * batch-level row index as input and returns an object whose property
- * values have been extracted from the batches.
- * @param {string[]} names The column (property) names
- * @param {import('./batch.js').Batch[]} batches The value batches.
- * @returns {(index: number) => Record<string, any>}
- */
-export function objectFactory(names, batches) {
-  return (index) => {
-    const r = {};
-    for (let i = 0; i < names.length; ++i) {
-      r[names[i]] = batches[i].at(index);
-    }
-    return r;
-  }
-}
-
 // -- flatbuffer utilities -----
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -87,6 +87,59 @@ export function bisect(offsets, index) {
   return a;
 }
 
+export const RowIndex = Symbol('rowIndex');
+
+/**
+ * Returns a row proxy object factory. The resulting method takes a
+ * batch-level row index as input and returns an object that proxies
+ * access to underlying batches.
+ * @param {string[]} names The column (property) names
+ * @param {import('./batch.js').Batch[]} batches The value batches.
+ * @returns {(index: number) => Record<string, any>}
+ */
+export function proxyFactory(names, batches) {
+  class RowObject {
+    constructor(index) {
+      this[RowIndex] = index;
+    }
+  };
+
+  // prototype for row proxy objects
+  const proto = RowObject.prototype;
+
+  for (let i = 0; i < names.length; ++i) {
+    // skip duplicated column names
+    if (Object.hasOwn(proto, names[i])) continue;
+
+    // add a getter method for the current batch
+    const batch = batches[i];
+    Object.defineProperty(proto, names[i], {
+      get() { return batch.at(this[RowIndex]); },
+      enumerable: true
+    });
+  }
+
+  return (index) => new RowObject(index);
+}
+
+/**
+ * Returns a row object factory. The resulting method takes a
+ * batch-level row index as input and returns an object whose property
+ * values have been extracted from the batches.
+ * @param {string[]} names The column (property) names
+ * @param {import('./batch.js').Batch[]} batches The value batches.
+ * @returns {(index: number) => Record<string, any>}
+ */
+export function objectFactory(names, batches) {
+  return (index) => {
+    const r = {};
+    for (let i = 0; i < names.length; ++i) {
+      r[names[i]] = batches[i].at(index);
+    }
+    return r;
+  }
+}
+
 // -- flatbuffer utilities -----
 
 /**


### PR DESCRIPTION
- Adds an option for representing `Struct` types and table row objects as zero-copy proxy objects with getter properties that retrieve data directly from underlying Arrow batches. This representation is enabled by passing a `useProxy` option to the `tableFromIPC` method. These proxies require substantially less memory and are faster for single-access use, but do not support object manipulation methods such as `Object.keys`, `Object.values`, and spreading `{ ...object }`.

The proxy representation follows the strategy of the [Vega arrow loader](https://github.com/vega/vega-loader-arrow/blob/main/src/arrow.js) and [suggestions](https://github.com/uwdata/flechette/issues/7) from @mcovalt.

Benchmarks show non-trivial performance improvements (25-35% reduced running time) for these proxy objects vs. vanilla JS objects: 26.72ms vs. 40.23ms for flights.arrows and 441.24ms vs. 576.23ms for scrabble.arrows. However, due to their simplicity and convenience methods, this PR leaves vanilla objects as the default object representation (hence the opt-in via `useProxy`). Both methods in Flechette remain substantially faster than the Arrow-JS reference implementation.