### PR TITLE
Redesign dictionary id use, add columnFromValues.

### DIFF
--- a/docs/api/data-types.md
+++ b/docs/api/data-types.md
@@ -85,14 +85,14 @@ Create a new field instance for use in a schema or type definition. A field repr
 ### Dictionary
 
 <hr/><a id="dictionary" href="#dictionary">#</a>
-<b>dictionary</b>(<i>type</i>[, <i>indexType</i>, <i>id</i>, <i>ordered</i>])
+<b>dictionary</b>(<i>type</i>[, <i>indexType</i>, <i>ordered</i>, <i>id</i>])
 
-Create a Dictionary data type instance. A dictionary type consists of a dictionary of values (which may be of any type) and corresponding integer indices that reference those values. If values are repeated, a dictionary encoding can provide substantial space savings. In the IPC format, dictionary indices reside alongside other columns in a record batch, while dictionary values are written to special dictionary batches, linked by a unique dictionary *id*. Internally Flechette extracts dictionary values upfront; while this incurs some initial overhead, it enables fast subsequent lookups.
+Create a Dictionary data type instance. A dictionary type consists of a dictionary of values (which may be of any type) and corresponding integer indices that reference those values. If values are repeated, a dictionary encoding can provide substantial space savings. In the IPC format, dictionary indices reside alongside other columns in a record batch, while dictionary values are written to special dictionary batches, linked by a unique dictionary *id* assigned at encoding time. Internally Flechette extracts dictionary values immediately upon decoding; while this incurs some initial overhead, it enables fast subsequent lookups.
 
 * *type* (`DataType`): The data type of dictionary values.
 * *indexType* (`DataType`): The data type of dictionary indices. Must be an integer type (default [`int32`](#int32)).
-* *id* (`number`): The dictionary id, should be unique in a table. Defaults to `-1`, but is set to a proper id if the type is passed through [`tableFromArrays`](/flechette/api/#tableFromArrays).
 * *ordered* (`boolean`): Indicates if dictionary values are ordered (default `false`).
+* *id* (`number`): Optional dictionary id. The default value (-1) indicates that the dictionary applies to a single column only. Provide an explicit id in order to reuse a dictionary across columns when building, in which case different dictionaries *must* have different unique ids. All dictionary ids are later resolved (possibly to new values) upon IPC encoding.
 
 ### Null
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -137,7 +137,7 @@ const col = columnFromArray(
 <hr/><a id="tableFromColumns" href="#tableFromColumns">#</a>
 <b>tableFromColumns</b>(<i>columns</i>[, <i>useProxy</i>])
 
-Create a new table from a collection of columns. This method is useful for creating new tables using one or more pre-existing column instances. Otherwise, [`tableFromArrays`](#tableFromArrays) should be preferred. Input columns are assumed to have the same record batch sizes and non-conflicting dictionary ids.
+Create a new table from a collection of columns. This method is useful for creating new tables using one or more pre-existing column instances. Otherwise, [`tableFromArrays`](#tableFromArrays) should be preferred. Input columns are assumed to have the same record batch sizes.
 
 * *data* (`object | array`): The input columns as an object with name keys, or an array of [name, column] pairs.
 * *useProxy* (`boolean`): Flag indicating if row proxy objects should be used to represent table rows (default `false`). Typically this should match the value of the `useProxy` extraction option used for column generation.

--- a/src/build/column-from-values.js
+++ b/src/build/column-from-values.js
@@ -1,0 +1,69 @@
+import { NullBatch } from '../batch.js';
+import { Column } from '../column.js';
+import { inferType } from './infer-type.js';
+import { builder, builderContext } from './builder.js';
+import { Type } from '../constants.js';
+
+/**
+ * Create a new column by iterating over provided values.
+ * @template T
+ * @param {number} length The input data length.
+ * @param {(visitor: (value: any) => void) => void} visit
+ *  A function that applies a callback to successive data values.
+ * @param {import('../types.js').DataType} type The data type.
+ * @param {import('../types.js').ColumnBuilderOptions} [options]
+ *  Builder options for the generated column.
+ * @param {ReturnType<
+ *    import('./builders/dictionary.js').dictionaryContext
+ *  >} [dicts] Builder context object, for internal use only.
+ * @returns {Column<T>} The generated column.
+ */
+export function columnFromValues(length, visit, type, options, dicts) {
+  type ??= inferType(visit);
+  const { maxBatchRows, ...opt } = options;
+  const limit = Math.min(maxBatchRows || Infinity, length);
+
+  // if null type, generate batches and exit early
+  if (type.typeId === Type.Null) {
+    return new Column(nullBatches(type, length, limit));
+  }
+
+  const ctx = builderContext(opt, dicts);
+  const b = builder(type, ctx).init();
+  const data = [];
+  const next = b => data.push(b.batch());
+
+  let row = 0;
+  visit(value => {
+    b.set(value, row++);
+    if (row >= limit) {
+      next(b);
+      row = 0;
+    }
+  });
+  if (row) next(b);
+
+  // resolve dictionaries
+  ctx.finish();
+
+  return new Column(data);
+}
+
+/**
+ * Create null batches with the given batch size limit.
+ * @param {import('../types.js').NullType} type The null data type.
+ * @param {number} length The total column length.
+ * @param {number} limit The maximum batch size.
+ * @returns {import('../batch.js').NullBatch[]} The null batches.
+ */
+function nullBatches(type, length, limit) {
+  const data = [];
+  const batch = length => new NullBatch({ length, nullCount: length, type });
+  const numBatches = Math.floor(length / limit);
+  for (let i = 0; i < numBatches; ++i) {
+    data.push(batch(limit));
+  }
+  const rem = length % limit;
+  if (rem) data.push(batch(rem));
+  return data;
+}

--- a/src/build/infer-type.js
+++ b/src/build/infer-type.js
@@ -3,14 +3,13 @@ import { isArray } from '../util/arrays.js';
 
 /**
  * Infer the data type for a given input array.
- * @param {import('../types.js').ValueArray} data The data array.
+ * @param {(visitor: (value: any) => void) => void} visit
+ *  A function that applies a callback to successive data values.
  * @returns {import('../types.js').DataType} The data type.
  */
-export function inferType(data) {
+export function inferType(visit) {
   const profile = profiler();
-  for (let i = 0; i < data.length; ++i) {
-    profile.add(data[i]);
-  }
+  visit(value => profile.add(value));
   return profile.type();
 }
 

--- a/src/build/table-from-arrays.js
+++ b/src/build/table-from-arrays.js
@@ -1,4 +1,4 @@
-import { builderContext } from './builder.js';
+import { dictionaryContext } from './builders/dictionary.js';
 import { columnFromArray } from './column-from-array.js';
 import { tableFromColumns } from './table-from-columns.js';
 
@@ -13,11 +13,11 @@ import { tableFromColumns } from './table-from-columns.js';
  */
 export function tableFromArrays(data, options = {}) {
   const { types = {}, ...opt } = options;
-  const ctx = builderContext();
+  const dicts = dictionaryContext();
   const entries = Array.isArray(data) ? data : Object.entries(data);
   const columns = entries.map(([name, array]) =>
     /** @type {[string, import('../column.js').Column]} */ (
-    [ name, columnFromArray(array, types[name], opt, ctx)]
+    [ name, columnFromArray(array, types[name], opt, dicts)]
   ));
   return tableFromColumns(columns, options.useProxy);
 }

--- a/src/build/table-from-columns.js
+++ b/src/build/table-from-columns.js
@@ -1,10 +1,10 @@
-import { Endianness, Type, Version } from '../constants.js';
+import { Endianness, Version } from '../constants.js';
 import { field } from '../data-types.js';
 import { Table } from '../table.js';
 
 /**
  * Create a new table from a collection of columns. Columns are assumed
- * to have the same record batch sizes and consistent dictionary ids.
+ * to have the same record batch sizes.
  * @param {[string, import('../column.js').Column][]
  *  | Record<string, import('../column.js').Column>} data The columns,
  *  as an object with name keys, or an array of [name, column] pairs.
@@ -14,20 +14,12 @@ import { Table } from '../table.js';
  */
 export function tableFromColumns(data, useProxy) {
   const fields = [];
-  const dictionaryTypes = new Map;
   const entries = Array.isArray(data) ? data : Object.entries(data);
   const length = entries[0]?.[1].length;
+
   const columns = entries.map(([name, col]) => {
     if (col.length !== length) {
       throw new Error('All columns must have the same length.');
-    }
-    const type = col.type;
-    if (type.typeId === Type.Dictionary) {
-      const dict = dictionaryTypes.get(type.id);
-      if (dict && dict !== type.dictionary) {
-        throw new Error('Same id used across different dictionaries.');
-      }
-      dictionaryTypes.set(type.id, type.dictionary);
     }
     fields.push(field(name, col.type));
     return col;
@@ -37,8 +29,7 @@ export function tableFromColumns(data, useProxy) {
     version: Version.V5,
     endianness: Endianness.Little,
     fields,
-    metadata: null,
-    dictionaryTypes
+    metadata: null
   };
 
   return new Table(schema, columns, useProxy);

--- a/src/data-types.js
+++ b/src/data-types.js
@@ -85,17 +85,21 @@ const basicType = (typeId) => ({ typeId });
  *  values.
  * @param {import('./types.js').IntType} [indexType] The data type of
  *  dictionary indices. Must be an integer type (default `int32`).
- * @param {number} [id=-1] The dictionary id, should be unique in a table.
  * @param {boolean} [ordered=false] Indicates if dictionary values are
  *  ordered (default `false`).
+ * @param {number} [id=-1] The dictionary id. The default value (-1) indicates
+ *  the dictionary applies to a single column only. Provide an explicit id in
+ *  order to reuse a dictionary across columns when building, in which case
+ *  different dictionaries *must* have different unique ids. All dictionary
+ *  ids are later resolved (possibly to new values) upon IPC encoding.
  * @returns {import('./types.js').DictionaryType}
  */
-export const dictionary = (type, indexType, id = -1, ordered = false) => ({
+export const dictionary = (type, indexType, ordered = false, id = -1) => ({
   typeId: Type.Dictionary,
   dictionary: type,
   indices: indexType || int32(),
-  id,
-  ordered
+  ordered,
+  id
 });
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,14 @@ export {
   largeListView
 } from './data-types.js';
 
+export { Batch } from './batch.js';
 export { Column } from './column.js';
 export { Table } from './table.js';
-export { Batch } from './batch.js';
 export { batchType } from './batch-type.js';
 export { tableFromIPC } from './decode/table-from-ipc.js';
 export { tableToIPC } from './encode/table-to-ipc.js';
 export { tableFromArrays } from './build/table-from-arrays.js';
 export { tableFromColumns } from './build/table-from-columns.js';
 export { columnFromArray } from './build/column-from-array.js';
+export { columnFromValues } from './build/column-from-values.js';
+export { dictionaryContext } from './build/builders/dictionary.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,8 +105,7 @@ export interface Schema {
   version?: Version_;
   endianness?: Endianness_;
   fields: Field[];
-  metadata?: Metadata | null;
-  dictionaryTypes?: Map<number, DataType>;
+  metadata?: Metadata | null
 }
 
 /**

--- a/test/infer-type-test.js
+++ b/test/infer-type-test.js
@@ -6,46 +6,50 @@ function matches(actual, expect) {
   assert.deepStrictEqual(actual, expect);
 }
 
+function infer(values) {
+  return inferType(visitor => values.forEach(visitor));
+}
+
 describe('inferType', () => {
   it('infers integer types', () => {
-    matches(inferType([1, 2, 3]), int8());
-    matches(inferType([1e3, 2e3, 3e3]), int16());
-    matches(inferType([1e6, 2e6, 3e6]), int32());
-    matches(inferType([1n, 2n, 3n]), int64());
+    matches(infer([1, 2, 3]), int8());
+    matches(infer([1e3, 2e3, 3e3]), int16());
+    matches(infer([1e6, 2e6, 3e6]), int32());
+    matches(infer([1n, 2n, 3n]), int64());
 
-    matches(inferType([-1, 2, 3]), int8());
-    matches(inferType([-1e3, 2e3, 3e3]), int16());
-    matches(inferType([-1e6, 2e6, 3e6]), int32());
-    matches(inferType([-1n, 2n, 3n]), int64());
+    matches(infer([-1, 2, 3]), int8());
+    matches(infer([-1e3, 2e3, 3e3]), int16());
+    matches(infer([-1e6, 2e6, 3e6]), int32());
+    matches(infer([-1n, 2n, 3n]), int64());
 
-    matches(inferType([1, 2, null, undefined, 3]), int8());
-    matches(inferType([1e3, 2e3, null, undefined, 3e3]), int16());
-    matches(inferType([1e6, 2e6, null, undefined, 3e6]), int32());
-    matches(inferType([1n, 2n, null, undefined, 3n]), int64());
+    matches(infer([1, 2, null, undefined, 3]), int8());
+    matches(infer([1e3, 2e3, null, undefined, 3e3]), int16());
+    matches(infer([1e6, 2e6, null, undefined, 3e6]), int32());
+    matches(infer([1n, 2n, null, undefined, 3n]), int64());
   });
 
   it('infers float types', () => {
-    matches(inferType([1.1, 2.2, 3.3]), float64());
-    matches(inferType([-1.1, 2.2, 3.3]), float64());
-    matches(inferType([1, 2, 3.3]), float64());
-    matches(inferType([1, 2, NaN]), float64());
-    matches(inferType([NaN, null, undefined, NaN]), float64());
-    matches(inferType([Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]), float64());
+    matches(infer([1.1, 2.2, 3.3]), float64());
+    matches(infer([-1.1, 2.2, 3.3]), float64());
+    matches(infer([1, 2, 3.3]), float64());
+    matches(infer([1, 2, NaN]), float64());
+    matches(infer([NaN, null, undefined, NaN]), float64());
+    matches(infer([Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]), float64());
   });
 
   it('infers utf8 dictionary types', () => {
     const type = dictionary(utf8(), int32());
-    matches(inferType(['foo', 'bar', 'baz']), type);
-    matches(inferType(['foo', 'bar', null, undefined, 'baz']), type);
+    matches(infer(['foo', 'bar', 'baz']), type);
+    matches(infer(['foo', 'bar', null, undefined, 'baz']), type);
   });
 
   it('infers bool types', () => {
-    matches(inferType([true, false, true]), bool());
-    matches(inferType([true, false, null, undefined, true]), bool());
+    matches(infer([true, false, true]), bool());
+    matches(infer([true, false, null, undefined, true]), bool());
   });
 
   it('infers date day types', () => {
-    matches(inferType([
+    matches(infer([
       new Date(Date.UTC(2000, 1, 2)),
       new Date(Date.UTC(2006, 3, 20)),
       null,
@@ -55,7 +59,7 @@ describe('inferType', () => {
 
   it('infers timestamp types', () => {
     matches(
-      inferType([
+      infer([
         new Date(Date.UTC(2000, 1, 2)),
         new Date(Date.UTC(2006, 3, 20)),
         null,
@@ -67,14 +71,14 @@ describe('inferType', () => {
   });
 
   it('infers list types', () => {
-    matches(inferType([[1, 2], [3, 4]]), list(int8()));
-    matches(inferType([[true, null, false], null, undefined, [false, undefined, true]]), list(bool()));
-    matches(inferType([['foo', 'bar', null], null, ['bar', 'baz']]), list(dictionary(utf8(), int32())));
+    matches(infer([[1, 2], [3, 4]]), list(int8()));
+    matches(infer([[true, null, false], null, undefined, [false, undefined, true]]), list(bool()));
+    matches(infer([['foo', 'bar', null], null, ['bar', 'baz']]), list(dictionary(utf8(), int32())));
   });
 
   it('infers struct types', () => {
     matches(
-      inferType([
+      infer([
         { foo: 1, bar: [1.1, 2.2] },
         { foo: null, bar: [2.2, null, 3.3] },
         null,
@@ -86,10 +90,10 @@ describe('inferType', () => {
   });
 
   it('throws on bigints that exceed 64 bits', () => {
-    assert.throws(() => inferType([(1n << 200n)]));
+    assert.throws(() => infer([(1n << 200n)]));
   });
 
   it('throws on mixed types', () => {
-    assert.throws(() => inferType([1, true, 'foo']));
+    assert.throws(() => infer([1, true, 'foo']));
   });
 });

--- a/test/table-to-ipc-test.js
+++ b/test/table-to-ipc-test.js
@@ -32,7 +32,6 @@ function testEncode(bytes) {
 
   // ensure complete schema, override version
   const schema = {
-    dictionaryTypes: new Map,
     endianness: 0,
     metadata: null,
     ...table.schema,

--- a/test/util/decimal.js
+++ b/test/util/decimal.js
@@ -11,8 +11,7 @@ export function decimalDataToEncode() {
         nullable: true,
         metadata: null
       }],
-      metadata: null,
-      dictionaryTypes: new Map
+      metadata: null
     },
     records: [{
       length: 3,


### PR DESCRIPTION
This PR redesigns how dictionary ids are used.

- Types: The `dictionary()` type constructor will set the id to a default value of -1 if not specified.
- Decoding: Dictionary ids are decoded and written to dictionary types by `tableFromIPC`.
- Encoding: The schema is analyzed and (potentially new) consecutive ids are assigned to each dictionary by `tableToIPC`. This effective serialization of tables that may have been built with conflicting dictionary ids.
- Building: Builders will treat a non-negative dictionary id as a signal for potential reuse, allowing the same backing dictionary values to be used across multiple columns. In this case, clients must take care not to provide overlapping ids for semantically separate dictionaries.
- Drop `dictionaryTypes` map from schema objects, as it is no longer needed. This also simplifies some of the decoding code.

In addition, this PR adds a new builder method that allows values to be provided by a visitor function:

- Add `columnFromValues` method. Instead of providing a materialized array, callers can provide a total length and a visit (or "scan") function that invokes a callback with each successive value.