### PR TITLE
Fix Generator's TNext type

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -155,7 +155,7 @@ export class Table {
 
   /**
    * Return an iterator over objects representing the rows of this table.
-   * @returns {Generator<Record<string, any>, any, null>}
+   * @returns {Generator<Record<string, any>, any, any>}
    */
   *[Symbol.iterator]() {
     const { children, getFactory } = this;


### PR DESCRIPTION
In the TypeScript definition:
```
interface Generator<T = unknown, TReturn = any, TNext = any> 
```
setting `TNext` to `null` can cause a typing error when `strictNullChecks` is enabled. For example:

```
error TS2763: Cannot iterate value because the 'next' method of its iterator expects type 'null', but for-of will always send 'undefined'.

288   for (const d of data) {
                      ~~~~
``` 
(from https://github.com/uwdata/mosaic/pull/792#discussion_r2150489237)

While the strict type for `TNext` should technically be `undefined`, since this generator function does not make use of the value passed to `.next()`, it's more flexible to keep it as `any`. This is the default type and helps avoid blocking compatibility with libraries that may pass a value to `.next()` (even if that value is unused in this generator).