### PR TITLE
export RowIndex 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,8 @@ export {
   largeListView
 } from './data-types.js';
 
+export { RowIndex } from './util/struct.js';
+
 export { Batch } from './batch.js';
 export { Column } from './column.js';
 export { Table } from './table.js';


### PR DESCRIPTION
Javascript novice here, so maybe this is not the way it's done

I wanted to access the index of each proxy row, and exporting the symbol seems like the easiest way

```javascript
import { tableFromIPC, RowIndex } from "flechette";

const table = tableFromIPC(data, { useProxy: true });
for (const row of table) {
	console.log(row[RowIndex]);
}
```