### PR TITLE
fix: Use cross-realm safe array checks.

### DIFF
--- a/src/decode/decode-ipc.js
+++ b/src/decode/decode-ipc.js
@@ -2,7 +2,7 @@
  * @import { ArrowData, Version_ } from '../types.js'
  */
 import { MAGIC, MessageHeader, Version } from '../constants.js';
-import { isArrayBufferLike } from '../util/arrays.js';
+import { isArrayBufferLike, isUint8Array } from '../util/arrays.js';
 import { readInt16, readInt32, readObject } from '../util/read.js';
 import { decodeBlocks } from './block.js';
 import { decodeMessage } from './message.js';
@@ -27,7 +27,7 @@ import { decodeSchema } from './schema.js';
  */
 export function decodeIPC(data) {
   const source = isArrayBufferLike(data) ? new Uint8Array(data) : data;
-  return source instanceof Uint8Array && isArrowFileFormat(source)
+  return isUint8Array(source) && isArrowFileFormat(source)
     ? decodeIPCFile(source)
     : decodeIPCStream(source);
 }
@@ -62,7 +62,7 @@ export function decodeIPCStream(data) {
 
   // consume each message in the stream
   for (const buf of stream) {
-    if (!(buf instanceof Uint8Array)) {
+    if (!isUint8Array(buf)) {
       throw new Error(`IPC data batch was not a Uint8Array.`);
     }
     let offset = 0;

--- a/src/util/arrays.js
+++ b/src/util/arrays.js
@@ -12,16 +12,28 @@ export const int64Array = BigInt64Array;
 export const float32Array = Float32Array;
 export const float64Array = Float64Array;
 
+function objectToString(value) {
+  return Object.prototype.toString.call(value);
+}
+
 /**
- * Check if an input value is an ArrayBuffer or SharedArrayBuffer.
+ * Check if an input value is an ArrayBuffer or SharedArrayBuffer,
+ * applicable cross-realms. 
  * @param {unknown} data
  * @returns {data is ArrayBufferLike}
  */
 export function isArrayBufferLike(data) {
-  return data instanceof ArrayBuffer || (
-    typeof SharedArrayBuffer !== 'undefined' &&
-    data instanceof SharedArrayBuffer
-  );
+  return objectToString(data) === '[object ArrayBuffer]' ||
+    objectToString(data) === '[object SharedArrayBuffer]';
+}
+
+/**
+ * Check in an input value is a Uint8Array, applicable cross-realms. 
+ * @param {unknown} value 
+ * @returns {value is Uint8Array}
+ */
+export function isUint8Array(value) {
+  return objectToString(value) === '[object Uint8Array]';
 }
 
 /**
@@ -40,17 +52,15 @@ export function intArrayType(bitWidth, signed) {
   )[i];
 }
 
-/** Shared prototype for typed arrays. */
-const TypedArray = Object.getPrototypeOf(Int8Array);
-
 /**
- * Check if a value is a typed array.
- * @param {*} value The value to check.
+ * Check if a value is a typed array, applicable cross-realms.
+ * @param {unknown} value The value to check.
  * @returns {value is TypedArray}
  *  True if value is a typed array, false otherwise.
  */
 export function isTypedArray(value) {
-  return value instanceof TypedArray;
+  return ArrayBuffer.isView(value)
+    && objectToString(value) !== '[object DataView]';
 }
 
 /**

--- a/src/util/arrays.js
+++ b/src/util/arrays.js
@@ -12,6 +12,10 @@ export const int64Array = BigInt64Array;
 export const float32Array = Float32Array;
 export const float64Array = Float64Array;
 
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
 function objectToString(value) {
   return Object.prototype.toString.call(value);
 }
@@ -23,8 +27,8 @@ function objectToString(value) {
  * @returns {data is ArrayBufferLike}
  */
 export function isArrayBufferLike(data) {
-  return objectToString(data) === '[object ArrayBuffer]' ||
-    objectToString(data) === '[object SharedArrayBuffer]';
+  return objectToString(data) === '[object ArrayBuffer]'
+    || objectToString(data) === '[object SharedArrayBuffer]';
 }
 
 /**


### PR DESCRIPTION
- Update array type check utilities to be safe across realms.

Data may come form different realms, such as in testing environments or from iframes, making `instanceof` unreliable. This PR adds different checks that are applicable across realms.